### PR TITLE
Wait a few seconds before stopping the output device to bridge gaps between tracks, episodes, ...

### DIFF
--- a/alsaloop.py
+++ b/alsaloop.py
@@ -43,7 +43,7 @@ PERIOD_SIZE = 1024
 # The duration of a measurement interval (after which the thresholds will be checked) in seconds.
 SAMPLE_SECONDS_BEFORE_CHECK = 0.5
 # The number of samples before each check
-SAMPLE_COUNT_BEFORE_CHECK = int(SAMPLE_RATE * SAMPLE_SECONDS_BEFORE_CHECK)
+SAMPLE_COUNT_BEFORE_CHECK = int((SAMPLE_RATE / CHANNELS) * SAMPLE_SECONDS_BEFORE_CHECK)
 # The time during which the input threshold hasn't been reached, before output is stopped.
 # This is useful for preventing the output device from turning off and on when there is a short silence in the input.
 SAMPLE_SECONDS_BEFORE_TURN_OFF = 15


### PR DESCRIPTION
This PR adds a waiting time before shutting down the output. This prevents popping/crackling when changing tracks/episodes/videos/....

### Current behaviour
Every 500 milliseconds, the maximum volume of the past 500ms is compared to a threshold to determine if the audio input is active. If the threshold is not met, the audio output is shut down (which causes cracking noises) and the the script goes into "detecting-mode" again where it waits on sufficiently high input.

### New behaviour
This pull requests alters the script in order to make it wait for a predefined time after the input threshold has not been met.
For example, when the interval to check thresholds is set to 500ms, and the `SAMPLE_SECONDS_BEFORE_TURN_OFF` timeout has been set to 15 seconds, there will be 30 measurement intervals before the output is switched off. If any of these 30 measurements is above the threshold, the counter is reset and the audio keeps playing. There has been no cracking up to this point. As soon as the audio is below the threshold for a time longer than the defined timeout, the output will switch off as usual, which might cause cracking as it does in the current behaviour.

#### Example output
Example debug output shows the new logic in action. The threshold has been set to -40db. As you can see, the audio needs to drop under the threshold for more than 15 seconds before it is cut off:
```
P -47.5 -36.0
P -49.1 -33.9
P -49.4 -37.8
P -46.5 -36.1
P -52.3 -41.2
P -52.2 -40.5
- -56.8 -44.1
No input signal for 1 intervals
- -57.5 -45.0
No input signal for 2 intervals
- -56.1 -42.2
No input signal for 3 intervals
- -54.9 -42.4
No input signal for 4 intervals
- -56.1 -44.2
No input signal for 5 intervals
- -55.8 -43.9
No input signal for 6 intervals
- -55.0 -42.3
No input signal for 7 intervals
P -54.7 -41.6
- -56.0 -42.9
No input signal for 1 intervals
P -55.4 -41.9
- -55.0 -42.6
No input signal for 1 intervals
- -55.5 -44.5
No input signal for 2 intervals
P -54.0 -39.1
- -53.5 -42.0
No input signal for 1 intervals
- -54.8 -43.0
No input signal for 2 intervals
- -55.3 -43.2
No input signal for 3 intervals
- -55.0 -43.3
No input signal for 4 intervals
P -53.8 -40.9
```
```
No input signal for 28 intervals
- -74.7 -62.7
No input signal for 29 intervals
- -74.9 -64.3
No input signal for 30 intervals
- -74.9 -64.7
No input signal for 31 intervals
Input signal lost, stopping playback
- -76.0 -63.1

```

### Related issues:
This wouldn't eliminate all popping/cracking since it would still shut off the output after a certain time, but it would significantly reduce the popping/cracking as described in https://github.com/hifiberry/hifiberry-os/issues/144

### Notes
This PR builds upon the clean-up and documentation improvements in PR #2 . The diff in this pull request will be easier to understand after PR #2 has been merged.

Please let me know if you would like to see any changes to this PR, if you think it can be improved, or if you believe this doesn't add sufficient value to the project.