### PR TITLE
Prevent hysteresis by using different start and stop thresholds

### DIFF
--- a/alsaloop.py
+++ b/alsaloop.py
@@ -75,9 +75,7 @@ if __name__ == '__main__':
             start_db_threshold = -start_db_threshold
 
         # Define the stop threshold. This prevents hysteresis when the volume fluctuates just around the threshold.
-        # 90% of the input threshold means the audio volume has to drop 10% after starting to play before playback
-        # will be stopped.
-        stop_db_threshold = start_db_threshold * .90
+        stop_db_threshold = start_db_threshold - 3
 
         print("using alsaloop with input level detection {:.1f} to start, {:.1f} to stop"
               .format(start_db_threshold, stop_db_threshold))

--- a/alsaloop.py
+++ b/alsaloop.py
@@ -75,16 +75,9 @@ if __name__ == '__main__':
             start_db_threshold = -start_db_threshold
 
         # Define the stop threshold. This prevents hysteresis when the volume fluctuates just around the threshold.
-        if len(sys.argv) > 2:
-            stop_db_threshold = float(sys.argv[2])
-            if stop_db_threshold > 0:
-                stop_db_threshold = -stop_db_threshold
-            # The threshold to stop playing should be lower than the threshold to start playing
-            stop_db_threshold = min(start_db_threshold, stop_db_threshold, start_db_threshold * .90)
-        else:
-            # If the stop threshold is not defined, use 90% of the start threshold.
-            # This means the audio volume has to drop 10% after starting to play before playback will be stopped.
-            stop_db_threshold = start_db_threshold * .90
+        # 90% of the input threshold means the audio volume has to drop 10% after starting to play before playback
+        # will be stopped.
+        stop_db_threshold = start_db_threshold * .90
 
         print("using alsaloop with input level detection {:.1f} to start, {:.1f} to stop"
               .format(start_db_threshold, stop_db_threshold))


### PR DESCRIPTION
This PR introduces different thresholds for starting and stopping playback. This means that, after starting, the audio is allowed to drop a little before it is considered to be "stopped". This prevents a phenomenon commonly known as hysteresis, where the output would quickly flip on and off when the input level is just around the threshold. 

![Hysteresis example](https://user-images.githubusercontent.com/1094793/97348150-0e57f480-188e-11eb-8239-6c790534d66b.png)


### Current behaviour
Assume the threshold is set to -40db.

- Audio starts playing at -39db.
- Input is detected, audio output is switched on
- Audio gets a bit softer and reaches -41db.
- Input is considered to be stopped, audio output is switched off
- Audio gets louder again, to -39db.
- Input is detected, audio output is switched on

### Proposed behaviour
Assume the starting threshold is set to -40db.

- The stopping threshold is automatically set to -43db.
- Audio starts playing at -39db.
- Input is detected, audio output is switched on
- Audio gets a bit softer and reaches -41db.
- Since the output is playing, the new audio level is compared to the stopping threshold of -43dp. Audio keeps playing.
- Audio gets louder again, to -39db.
- Since the output is playing, the new audio level is compared to the stopping threshold of -43dp. Audio keeps playing.

#### Example output
This is example output from a test run with the start threshold set -40db:
```
- -56.0 -42.9
P -46.5 -36.1
P -52.3 -41.2
P -52.2 -40.5
- -56.8 -44.1
```
- The first measurement isn't high enough to trip the start threshold
- The second measurement trips the start threshold, output is started,
- The third measurement is below the start threshold, but above the stop threshold of -43db. Still considered as playing.
- The fourth measurement is below the start threshold, but above the stop threshold of -43db. Still considered as playing.
- The fifth measurement is below the stop threshold of -43db. Stop playing.

### Notes
This PR is an addition on top of PR #3 . Where the other pull request focusses on a complete silence during a couple of seconds, this one focusses on music with longer, softer parts. For example, a song that goes under the start threshold for 30 seconds would still keep playing uninterrupted due to the proposed changes in this PR. Both PRs work nicely together. 

The current value of -3db offers a rather small buffer, but it's easy to experiment with this value and change it for a larger buffer.
If needed, this value could be made configurable by command line parameters or a config file.

Please let me know if you would like to see any changes to this PR, if you think it can be improved, or if you believe this doesn't add sufficient value to the project.