### PR TITLE
Fix alsaloopmpris play/pause detection, minor improvement to alsaloop sound detection

### DIFF
--- a/alsaloop.py
+++ b/alsaloop.py
@@ -162,12 +162,12 @@ if __name__ == '__main__':
             # Check if the threshold has been exceeded
             if start_db_threshold == 0 or decibel(max_sample) > threshold:
                 input_detected = True
-                status = "P"
             else:
                 input_detected = False
-                status = "-"
 
-            print("{} {:.1f} {:.1f}".format(status, decibel(rms_volume), decibel(max_sample)), flush=True)
+            triggered_status_string = "T" if input_detected else "-"
+            active_status_str = "A" if not output_stopped else "-"
+            print("{} {} {:.1f} {:.1f}".format(active_status_str, triggered_status_string, decibel(rms_volume), decibel(max_sample)), flush=True)
 
             sample_sum = 0
             samples = 0
@@ -189,6 +189,7 @@ if __name__ == '__main__':
                 if count_playback_threshold_not_met > CHECK_NUMBER_BEFORE_TURN_OFF:
                     del input_device
                     output_device = None
+                    print("Input signal lost, stopping playback")
                     logging.info("Input signal lost, stopping playback")
                     input_device = open_sound(output=False)
                     output_stopped = True

--- a/alsaloop.py
+++ b/alsaloop.py
@@ -53,7 +53,7 @@ SAMPLE_SECONDS_BEFORE_TURN_OFF = 15
 # The number of checks which have to fail before audio is turned off.
 CHECK_NUMBER_BEFORE_TURN_OFF = int(SAMPLE_SECONDS_BEFORE_TURN_OFF / SAMPLE_SECONDS_BEFORE_CHECK)
 # The number of checks which have to pass before audio is turned on.
-CHECK_NUMBER_BEFORE_TURN_ON = 2
+CHECK_NUMBER_BEFORE_TURN_ON = 3
 
 
 def open_sound(output=False):

--- a/alsaloopmpris.py
+++ b/alsaloopmpris.py
@@ -225,20 +225,20 @@ class ALSALoopWrapper(threading.Thread):
                     
             line = self.alsaloopclient.stdout.readline()
 
-            parts=line.split(" ")
             pbstatus_old = self.playback_status
-            if len(parts)>2:
-                if parts[0].lower()=="p":
-                    self.playback_status = PLAYBACK_PLAYING
-                elif parts[0]=="-":
-                    self.playback_status = PLAYBACK_STOPPED
+
+            # Use the first character of the line for active/inactive state detection
+            if line[0] == "A":
+                self.playback_status = PLAYBACK_PLAYING
+            elif line[0] == "-":
+                self.playback_status = PLAYBACK_STOPPED
                     
-                # Ignore decibel for the moment
-                #try:
-                #    db = float(parts[1])
-                #except:
-                #    db = 0
-                
+            # Ignore decibel for the moment
+            #try:
+            #    db = float(parts[1])
+            #except:
+            #    db = 0
+
             if self.playback_status != pbstatus_old:
                 logging.info("playback status changed from %s to %s",pbstatus_old, self.playback_status)
             


### PR DESCRIPTION
- The MPRIS wrapper only looked at the input volume when determining the play/pause state, instead of the output active/stopped status. The output active/stopped status is now printed as well and parsed in alsaloopMPRIS to ensure the MPRIS/DBUS state matches the actual state of alsaloop.

- Require 3 consecutive intervals of 0.25s audio playing before triggering output. Previously this was one interval of 0.5s. This reduces "accidental" triggers when the detected input volume spikes although nothing is playing